### PR TITLE
riscv (rv64g) support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -770,7 +770,7 @@ AC_DEFINE_UNQUOTED(ENABLE_UFFD_MONITOR, [$enable_uffd],
 
 
 AH_BOTTOM([
-#if defined(__linux__) && (defined(__x86_64__) || defined(__amd64__) || defined(__aarch64__)) && ENABLE_MEMHOOKS_MONITOR
+#if defined(__linux__) && (defined(__x86_64__) || defined(__amd64__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64)) && ENABLE_MEMHOOKS_MONITOR
 #define HAVE_MEMHOOKS_MONITOR 1
 #else
 #define HAVE_MEMHOOKS_MONITOR 0

--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,7 @@ dnl Copyright (c) 2019-2021 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
 dnl (C) Copyright 2020 Hewlett Packard Enterprise Development LP
 dnl Copyright (c) 2022 DataDirect Networks, Inc. All rights reserved.
+dnl Copyright (c) 2023 Tactical Computing Labs, LLC. All rights reserved.
 dnl
 dnl Process this file with autoconf to produce a configure script.
 

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -295,7 +295,47 @@ ofi_cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
 	asm volatile("clflush %0" : "+m" (*(volatile char *) addr))
 #define ofi_sfence() asm volatile("sfence" ::: "memory")
 
-#else /* defined(__x86_64__) || defined(__amd64__) */
+#elif ( defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 64) && (defined(__linux__) || defined(__APPLE__)) )
+/*
+#include <stdio.h>
+#include <regex.h>
+
+static inline void
+ofi_cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
+{
+     FILE *f = fopen("/proc/cpuinfo", "r");
+
+     regex_t r;
+     regmatch_t  match[1];
+
+     regcomp(&r, "hart", 0);
+     unsigned int hart = 0;
+     size_t lsz = 1024;
+     char *line = malloc(1024);
+     size_t rc = getline(&line, &lsz, f);
+     while(rc != -1 && 0 < rc) {
+         if(!regexec(&r, line, sizeof(match) / sizeof(match[0]), match, 0)) {
+            hart+=1;
+         }
+         
+         rc = getline(&line, &lsz, f);
+     }
+
+     regfree(&r);
+
+     cpuinfo[0] = hart & 0x000000FF;
+     cpuinfo[1] = hart & 0x0000FF00;
+     cpuinfo[2] = hart & 0x00FF0000;
+     cpuinfo[3] = hart & 0xFF000000;
+}
+*/
+#define ofi_cpuid(func, subfunc, cpuinfo)
+#define ofi_clwb(addr)
+#define ofi_clflushopt(addr)
+#define ofi_clflush(addr)
+#define ofi_sfence() asm volatile("fence w,w" ::: "memory")
+
+#else /* defined(__x86_64__) || defined(__amd64__) || defined(__riscv) */
 
 #define ofi_cpuid(func, subfunc, cpuinfo)
 #define ofi_clwb(addr)

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
+ * Copyright (c) 2023 Tactical Computing Labs, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -296,7 +297,7 @@ ofi_cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
 #define ofi_sfence() asm volatile("sfence" ::: "memory")
 
 #elif ( defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 64) && (defined(__linux__) || defined(__APPLE__)) )
-/*
+
 #include <stdio.h>
 #include <regex.h>
 
@@ -328,8 +329,7 @@ ofi_cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
      cpuinfo[2] = hart & 0x00FF0000;
      cpuinfo[3] = hart & 0xFF000000;
 }
-*/
-#define ofi_cpuid(func, subfunc, cpuinfo)
+
 #define ofi_clwb(addr)
 #define ofi_clflushopt(addr)
 #define ofi_clflush(addr)

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -17,6 +17,7 @@
  * Copyright (c) 2016-2020 IBM Corporation.  All rights reserved.
  * Copyright (c) 2019 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2023 Tactical Computing Labs, LLC. All rights reserved.
  *
  * License text from Open-MPI (www.open-mpi.org/community/license.php)
  *

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -176,7 +176,7 @@ static inline void ofi_clear_instruction_cache(uintptr_t address, size_t data_si
 {
 	size_t i;
 	size_t offset_jump = 16;
-#if defined(__aarch64__)
+#if (defined(__aarch64__) || (defined(__riscv) && (__riscv_xlen == 64)))
 	offset_jump = 32;
 #endif
 	/* align the address */
@@ -186,12 +186,15 @@ static inline void ofi_clear_instruction_cache(uintptr_t address, size_t data_si
 #if (defined(__x86_64__) || defined(__amd64__))
 		__asm__ volatile("mfence;clflush %0;mfence"::
 				 "m" (*((char*) address + i)));
-#elif defined(__aarch64__)
+#elif (defined(__aarch64__)
 		__asm__ volatile ("dc cvau, %0\n\t"
 			  "dsb ish\n\t"
 			  "ic ivau, %0\n\t"
 			  "dsb ish\n\t"
 			  "isb":: "r" (address + i));
+#elif (defined(__riscv) && (__riscv_xlen == 64)
+	        __riscv_flush_icache(address, address+data_size, SYS_RISCV_FLUSH_ICACHE_LOCAL);
+		__asm__ volatile ("fence.i\n");
 #endif
 	}
 }
@@ -371,6 +374,85 @@ static bool ofi_is_function_patched(struct ofi_intercept *intercept)
         ((*(uint32_t *) (addr +  8)) & mov_mask) == movk(0, 1, 0) &&
         ((*(uint32_t *) (addr + 12)) & mov_mask) == movk(0, 0, 0) &&
         ((*(uint32_t *) (addr + 16)) & br_mask) == br(0)
+	);
+}
+#elif (defined(__riscv) && defined(__riscv_xlen) && (__riscv_xlen == 64))
+
+/* Registers numbers to use with the move immediate to register.
+ * The destination register is X31 (highest temporary).
+ * Register X28-X30 are used for block shifting and masking.
+ * Register X0 is always zero
+ */
+#define X31 31
+#define X30 30
+#define X0  0
+
+/**
+ * @brief JALR - Add 12 bit immediate to source register, save to destination register, jump and link from destination register
+ *
+ * @param[in] _reg  register number (0-31), @param[out] _reg register number (0-31), @param[imm] 12 bit immmediate value
+ */
+#define JALR(_regs, _regd, _imm) (((_imm) << 20) | ((_regs) << 15) | (0b000 << 12) | ((_regd) << 7) | (0x67))
+
+/**
+ * @brief ADDI - Add 12 bit immediate to source register, save to destination register 
+ *
+ * @param[in] _reg  register number (0-31), @param[out] _reg register number (0-31), @param[imm] 12 bit immmediate value
+ */
+#define ADDI(_regs, _regd, _imm) (((_imm) << 20) | ((_regs) << 15) | (0b000 << 12) | ((_regd) << 7) | (0x13))
+#define ADD(_regs_a, _regs_b, _regd) ((_regs_b << 20) | (_regs_a << 15) | (0b000 << 12) | ((_regd) << 7) | (0x33))
+
+/**
+ * @brief LUI - load upper 20 bit immediate to destination register
+ *
+ * @param[in] _reg  register number (0-31), @param[out] _reg register number (0-31), @param[imm] 12 bit immmediate value
+ */
+#define LUI(_regd, _imm) (((_imm) << 12) | ((_regd) << 7) | (0x37))
+
+/**
+ * @brief SLLI - left-shift immediate number of bits in source register into destination register
+ *
+ * @param[in] _reg  register number (0-31), @param[out] _reg register number (0-31), @param[imm] 12 bit immmediate value
+ */
+#define SLLI(_regs, _regd, _imm) (((_imm) << 20) | ((_regs) << 15) | (0b001 << 12) | ((_regd) << 7) | (0x13))
+
+static int ofi_patch_function(struct ofi_intercept *intercept)
+{
+    /*
+     * r15 is the highest numbered temporary register. I am
+     * assuming this one is safe to use.
+     */
+    uintptr_t addr = (uintptr_t) intercept->patch_data;
+    uintptr_t value = (uintptr_t) intercept->our_func;
+
+    *(uint32_t*) (addr +  0) = LUI  (X31, ((0xFFFFF << 12) & ( ((value) >> 32) + 1 ) ) >> 12);
+    *(uint32_t*) (addr +  4) = ADDI (X31, X31, ((0xFFF)    & ( ((value) >> 32) + 1 ) )      );
+    *(uint32_t*) (addr +  8) = LUI  (X30, ((0xFFFFF << 12) & ( (((value)) + 1)     ) ) >> 12);
+    *(uint32_t*) (addr + 12) = SLLI (X31, X31, 32);
+    *(uint32_t*) (addr + 16) = ADD  (X30, X31, X31);
+    *(uint32_t*) (addr + 20) = JALR (X31, X0, ((0xFFF)     & ( ((value)) + 1)));
+
+    intercept->patch_data_size = 24;
+
+    return ofi_apply_patch(intercept);
+}
+
+/*
+ * Please see comments at other ofi_is_function_patched() function
+ */
+static bool ofi_is_function_patched(struct ofi_intercept *intercept)
+{
+    uintptr_t addr = (uintptr_t) intercept->orig_func;
+    /*
+     * focus on the instructions in the bytes.
+     */
+    return (
+        ((*(uint32_t *) (addr +  0)) & 0xFF) == 0x37 &&
+        ((*(uint32_t *) (addr +  4)) & 0xFF) == 0x13 &&
+        ((*(uint32_t *) (addr +  8)) & 0xFF) == 0x37 &&
+        ((*(uint32_t *) (addr + 12)) & 0xFF) == 0x13 &&
+        ((*(uint32_t *) (addr + 16)) & 0xFF) == 0x33 &&
+        ((*(uint32_t *) (addr + 20)) & 0xFF) == 0x67
 	);
 }
 #endif


### PR DESCRIPTION
This PR provides initial support for RISC-V (rv64g). The implementation has added risc-v (rv64g) specific autoconf fixes and the binary instrumentation C code necessary for memory call hook support.

Developer's Notes:

rv64g is the base suite of extensions for a 64-bit risc-v processor. Prior work performed by Tactical Computing Labs (TCL) porting [UCX](https://github.com/openucx/ucx/pull/8246) to rv64g demonstrated instruction and data cache management instructions are critical for memory hooks using binary instrumentation (self-modifying code) to work correctly; UCX has binary instrumentation similar in implementation logic to libfabric.

rv64g is able to fence memory but is not able to flush cache's directly with user-land code. Additionally, the linux kernel's memory management subsystem for risc-v (pagetable, etc) is implemented in software which can cause some issues clearing caches and updating memory pages. gcc and clang provide intrinsics that claim to support cache flushes but the underlying implementation of those intrinsics use memory fences. This is a situation where the kernel and the hardware need some additional work at the vendor level.

risc-v has the CMOBase extension (cache-management-operation base) which provides a collection of instructions to handle data and instructions caches. libfabric's memory hook implementation uses binary instrumentation so this patch's mileage may vary on the available hardware.

An alternative mechanism to perform binary instrumentation involves modifying the global offset table (GOT) and the procedure linkage table (PLT) using ELF support library functionality. Of course this complicates libfabric support for Windows and Darwin. Below are links to the ELF support that would enable the PLT/GOT technique's implementation.

*[elf manpage](https://man7.org/linux/man-pages/man5/elf.5.html)
*[elf dl_iterate_phdr manpage](https://man7.org/linux/man-pages/man3/dl_iterate_phdr.3.html)